### PR TITLE
Fix disposable product label formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,12 +547,14 @@
         {code:'CT', label:'雞肉零食'},
         {code:'BR', label:'(水)牛肉零食'},
         {code:'SL', label:'鮭魚零食'},
-        {code:'SD', label:'鮭魚潔牙骨'}
+        {code:'SD', label:'鮭魚潔牙骨'},
+        {code:'XX', label:'一次性產品'}
       ],
       'C': [
         {code:'MD', label:'低溫風乾糧'},
         {code:'MC', label:'朕是喵罐頭'},
-        {code:'MT', label:'卵磷脂肉條'}
+        {code:'MT', label:'卵磷脂肉條'},
+        {code:'XX', label:'一次性產品'}
       ],
       'G': [
         {code:'CR', label:'雞肉系列'},
@@ -575,7 +577,8 @@
         {code:'TA', label:'火雞筋麻花辮'},
         {code:'TO', label:'火雞筋卷'},
         {code:'TC', label:'火雞筋帶肉嚼片'},
-        {code:'TT', label:'火雞肉零食'}
+        {code:'TT', label:'火雞肉零食'},
+        {code:'XX', label:'一次性產品'}
       ],
       'H': [
         {code:'SP', label:'單一純肉系列'},
@@ -588,7 +591,8 @@
         {code:'DS', label:'火雞筋雞肉條'},
         {code:'DB', label:'火雞筋雞肉骨'},
         {code:'DP', label:'火雞筋雞肉八字'},
-        {code:'DA', label:'火雞筋雞肉麻花'}
+        {code:'DA', label:'火雞筋雞肉麻花'},
+        {code:'XX', label:'一次性產品'}
       ],
       'K': [
         {code:'MD', label:'低溫風乾糧'},
@@ -597,7 +601,8 @@
         {code:'DF', label:'功能潔牙骨'},
         {code:'DC', label:'潔牙骨(人通)'},
         {code:'DQ', label:'軟Q潔牙骨'},
-        {code:'CL', label:'零食系列KCL'}
+        {code:'CL', label:'零食系列KCL'},
+        {code:'XX', label:'一次性產品'}
       ],
       'M': [
         {code:'HD', label:'機能健康糧'},
@@ -608,11 +613,13 @@
         {code:'ZD', label:'漢方健康糧'},
         {code:'ZC', label:'漢方主食罐'},
         {code:'ZT', label:'漢方養生大補帖'},
-        {code:'ZS', label:'保健嚼棒'}
+        {code:'ZS', label:'保健嚼棒'},
+        {code:'XX', label:'一次性產品'}
       ],
       'R': [
         {code:'MD', label:'乾糧'},
-        {code:'MT', label:'滿分零食'}
+        {code:'MT', label:'滿分零食'},
+        {code:'XX', label:'一次性產品'}
       ],
       'V': [
         {code:'VD', label:'每朝活力小'},
@@ -630,7 +637,8 @@
         {code:'FR', label:'巴沙魚皮甜甜圈'},
         {code:'FB', label:'巴沙魚皮打結骨'},
         {code:'FA', label:'巴沙魚皮麻花辮'},
-        {code:'DF', label:'機能潔牙棒'}
+        {code:'DF', label:'機能潔牙棒'},
+        {code:'XX', label:'一次性產品'}
       ]
     };
     const feedPrefixes = [


### PR DESCRIPTION
## Summary
- remove the duplicated code suffix from the disposable series labels so the dropdown shows `一次性產品(XX)` only once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e484155f8083209d8b60f71fd4f25d